### PR TITLE
Use references instead of array_replace_recursive()

### DIFF
--- a/core-bundle/src/EventListener/DataContainerCallbackListener.php
+++ b/core-bundle/src/EventListener/DataContainerCallbackListener.php
@@ -78,7 +78,7 @@ class DataContainerCallbackListener
 
     private function addCallbacks(?array &$dcaRef, array $callbacks): void
     {
-        if (!\is_array($dcaRef)) {
+        if (null === $dcaRef) {
             $dcaRef = [];
         }
 

--- a/core-bundle/src/EventListener/DataContainerCallbackListener.php
+++ b/core-bundle/src/EventListener/DataContainerCallbackListener.php
@@ -72,7 +72,8 @@ class DataContainerCallbackListener
         krsort($callbacks, SORT_NUMERIC);
 
         if (empty($dcaRef) || array_keys($callbacks)[0] >= 0) {
-            $dcaRef = array_values($callbacks[array_keys($callbacks)[0]])[0];
+            $callbacks = array_shift($callbacks);
+            $dcaRef = array_shift($callbacks);
         }
     }
 

--- a/core-bundle/src/EventListener/DataContainerCallbackListener.php
+++ b/core-bundle/src/EventListener/DataContainerCallbackListener.php
@@ -38,78 +38,64 @@ class DataContainerCallbackListener
             return;
         }
 
-        $replaces = [];
-
         foreach ($this->callbacks[$table] as $target => $callbacks) {
             $keys = explode('.', $target);
-            $current = $this->getFromDCA($table, $keys);
+            $dcaRef = &$this->getDcaReference($table, $keys);
 
             if (\in_array(end($keys), self::SINGLETONS, true)) {
-                $value = $this->getFirstByPriority($callbacks, $current);
+                $this->updateSingleton($dcaRef, $callbacks);
             } else {
-                $value = $this->getMergedByPriority($callbacks, $current);
+                $this->addCallbacks($dcaRef, $callbacks);
             }
-
-            foreach (array_reverse($keys) as $key) {
-                $value = [$key => $value];
-            }
-
-            $replaces[] = $value;
         }
-
-        $GLOBALS['TL_DCA'][$table] = array_replace_recursive($GLOBALS['TL_DCA'][$table], ...$replaces);
     }
 
     /**
-     * @return array|\Closure|null
+     * @return array|callable|null
      */
-    private function getFromDCA(string $table, array $keys)
+    private function &getDcaReference(string $table, array $keys)
     {
-        if (!isset($GLOBALS['TL_DCA'][$table])) {
-            $GLOBALS['TL_DCA'][$table] = [];
-        }
-
-        $dca = $GLOBALS['TL_DCA'][$table];
+        $dcaRef = &$GLOBALS['TL_DCA'][$table];
 
         foreach ($keys as $key) {
-            if (!isset($dca[$key])) {
-                return null;
-            }
-
-            $dca = $dca[$key];
+            $dcaRef = &$dcaRef[$key];
         }
 
-        return $dca;
+        return $dcaRef;
     }
 
     /**
-     * @param array|callable|null $current
-     *
-     * @return array|callable
+     * @param array|callable|null &$dcaRef
      */
-    private function getFirstByPriority(array $callbacks, $current)
+    private function updateSingleton(&$dcaRef, array $callbacks): void
     {
-        if (null !== $current) {
-            $current = [$current];
+        krsort($callbacks, SORT_NUMERIC);
+
+        if (empty($dcaRef) || array_keys($callbacks)[0] >= 0) {
+            $dcaRef = array_values($callbacks[array_keys($callbacks)[0]])[0];
         }
-
-        $callbacks = $this->getMergedByPriority($callbacks, $current);
-
-        return array_shift($callbacks);
     }
 
-    private function getMergedByPriority(array $callbacks, ?array $current): array
+    private function addCallbacks(?array &$dcaRef, array $callbacks): void
     {
-        if (null !== $current) {
-            if (!isset($callbacks[0])) {
-                $callbacks[0] = [];
-            }
-
-            $callbacks[0] = array_merge($callbacks[0], $current);
+        if (!\is_array($dcaRef)) {
+            $dcaRef = [];
         }
 
         krsort($callbacks, SORT_NUMERIC);
 
-        return array_merge(...$callbacks);
+        $preCallbacks = array_merge([], ...array_filter($callbacks, function($priority) {
+            return $priority >= 0;
+        }, ARRAY_FILTER_USE_KEY));
+        $postCallbacks = array_merge([], ...array_filter($callbacks, function($priority) {
+            return $priority < 0;
+        }, ARRAY_FILTER_USE_KEY));
+
+        if (\count($preCallbacks)) {
+            array_unshift($dcaRef, ...$preCallbacks);
+        }
+        if (\count($postCallbacks)) {
+            array_push($dcaRef, ...$postCallbacks);
+        }
     }
 }

--- a/core-bundle/tests/EventListener/DataContainerCallbackListenerTest.php
+++ b/core-bundle/tests/EventListener/DataContainerCallbackListenerTest.php
@@ -199,6 +199,7 @@ class DataContainerCallbackListenerTest extends TestCase
             'config' => [
                 'onload_callback' => [
                     ['Test\CallbackListener', 'priority0Callback'],
+                    'key' => ['Test\CallbackListener', 'priority0Callback2'],
                 ],
             ],
         ];
@@ -227,6 +228,7 @@ class DataContainerCallbackListenerTest extends TestCase
                     'onload_callback' => [
                         ['Test\CallbackListener', 'priority10Callback'],
                         ['Test\CallbackListener', 'priority0Callback'],
+                        'key' => ['Test\CallbackListener', 'priority0Callback2'],
                         ['Test\CallbackListener', 'priorityMinus10Callback'],
                     ],
                 ],
@@ -241,6 +243,8 @@ class DataContainerCallbackListenerTest extends TestCase
             'config' => [
                 'onload_callback' => [
                     ['Test\CallbackListener', 'existingCallback'],
+                    'key' => ['Test\CallbackListener', 'existingCallback2'],
+                    ['Test\CallbackListener', 'existingCallback3'],
                 ],
             ],
         ];
@@ -266,6 +270,8 @@ class DataContainerCallbackListenerTest extends TestCase
                     'onload_callback' => [
                         ['Test\CallbackListener', 'newCallback'],
                         ['Test\CallbackListener', 'existingCallback'],
+                        'key' => ['Test\CallbackListener', 'existingCallback2'],
+                        ['Test\CallbackListener', 'existingCallback3'],
                     ],
                 ],
             ],
@@ -315,9 +321,7 @@ class DataContainerCallbackListenerTest extends TestCase
         $GLOBALS['TL_DCA']['tl_page'] = [
             'list' => [
                 'label' => [
-                    'label_callback' => [
-                        ['Test\CallbackListener', 'existingCallback'],
-                    ],
+                    'label_callback' => ['Test\CallbackListener', 'existingCallback'],
                 ],
             ],
         ];
@@ -342,6 +346,43 @@ class DataContainerCallbackListenerTest extends TestCase
                 'list' => [
                     'label' => [
                         'label_callback' => ['Test\CallbackListener', 'newCallback'],
+                    ],
+                ],
+            ],
+            $GLOBALS['TL_DCA']['tl_page']
+        );
+    }
+
+    public function testNewCallbackWithNegativePriorityDoesNotOverrideExistingForSingletons(): void
+    {
+        $GLOBALS['TL_DCA']['tl_page'] = [
+            'list' => [
+                'label' => [
+                    'label_callback' => ['Test\CallbackListener', 'existingCallback'],
+                ],
+            ],
+        ];
+
+        $this->listener->setCallbacks(
+            [
+                'tl_page' => [
+                    'list.label.label_callback' => [
+                        -1 => [
+                            ['Test\CallbackListener', 'newCallback'],
+                        ],
+                    ],
+                ],
+            ]
+        );
+
+        $this->listener->onLoadDataContainer('tl_page');
+
+        $this->assertNotEmpty($GLOBALS['TL_DCA']['tl_page']);
+        $this->assertSame(
+            [
+                'list' => [
+                    'label' => [
+                        'label_callback' => ['Test\CallbackListener', 'existingCallback'],
                     ],
                 ],
             ],


### PR DESCRIPTION
I rewrote the `DataContainerCallbackListener` to use references to the `$GLOBALS['TL_DCA']` array instead of using `array_replace_recursive()`.

This fixes an issue with callback arrays that use string keys and should also consume less memory because it doesn’t copy the whole `$GLOBALS['TL_DCA'][$table]` array.

I hope you like it ☺️