### PR TITLE
Use insert tag argument instead of a flag

### DIFF
--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -459,7 +459,7 @@ class InsertTags extends Controller
 						$strTitle = $objNextPage->pageTitle ?: $objNextPage->title;
 					}
 
-					if ($elements[2] ?? '' === 'blank' && !$strTarget)
+					if (!$strTarget && \in_array('blank', \array_slice($elements, 2), true))
 					{
 						$strTarget = ' target="_blank" rel="noreferrer noopener"';
 					}
@@ -539,7 +539,7 @@ class InsertTags extends Controller
 					/** @var PageModel $objPid */
 					$params = '/articles/' . ($objArticle->alias ?: $objArticle->id);
 					$strUrl = \in_array('absolute', $flags, true) ? $objPid->getAbsoluteUrl($params) : $objPid->getFrontendUrl($params);
-					$strTarget = $elements[2] ?? null === 'blank' ? ' target="_blank" rel="noreferrer noopener"' : '';
+					$strTarget = \in_array('blank', \array_slice($elements, 2), true) ? ' target="_blank" rel="noreferrer noopener"' : '';
 
 					// Replace the tag
 					switch (strtolower($elements[0]))

--- a/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
+++ b/core-bundle/src/Resources/contao/library/Contao/InsertTags.php
@@ -454,9 +454,14 @@ class InsertTags extends Controller
 						}
 
 						$strName = $objNextPage->title;
-						$strTarget = $objNextPage->target || \in_array('blank', $flags, true) ? ' target="_blank" rel="noreferrer noopener"' : '';
+						$strTarget = $objNextPage->target ? ' target="_blank" rel="noreferrer noopener"' : '';
 						$strClass = $objNextPage->cssClass ? sprintf(' class="%s"', $objNextPage->cssClass) : '';
 						$strTitle = $objNextPage->pageTitle ?: $objNextPage->title;
+					}
+
+					if ($elements[2] ?? '' === 'blank' && !$strTarget)
+					{
+						$strTarget = ' target="_blank" rel="noreferrer noopener"';
 					}
 
 					// Replace the tag
@@ -534,7 +539,7 @@ class InsertTags extends Controller
 					/** @var PageModel $objPid */
 					$params = '/articles/' . ($objArticle->alias ?: $objArticle->id);
 					$strUrl = \in_array('absolute', $flags, true) ? $objPid->getAbsoluteUrl($params) : $objPid->getFrontendUrl($params);
-					$strTarget = \in_array('blank', $flags, true) ? ' target="_blank" rel="noreferrer noopener"' : '';
+					$strTarget = $elements[2] ?? null === 'blank' ? ' target="_blank" rel="noreferrer noopener"' : '';
 
 					// Replace the tag
 					switch (strtolower($elements[0]))
@@ -1140,7 +1145,6 @@ class InsertTags extends Controller
 						case 'absolute':
 						case 'refresh':
 						case 'uncached':
-						case 'blank':
 							// ignore
 							break;
 


### PR DESCRIPTION
This would use an insert tag argument instead of a flag. (I also think that the `absolute` flag is wrong but this is a different topic).

It also would make the argument work with all types of links like external links: `{{link::https://example.com::blank}}`

See https://github.com/contao/contao/pull/3142#issuecomment-872155666