### PR TITLE
fix AbstractBackendControllerTest

### DIFF
--- a/core-bundle/tests/Controller/AbstractBackendControllerTest.php
+++ b/core-bundle/tests/Controller/AbstractBackendControllerTest.php
@@ -100,6 +100,7 @@ class AbstractBackendControllerTest extends TestCase
             'learnMore' => 'learn more',
             'menu' => '<menu>',
             'headerMenu' => '<header_menu>',
+            'ua' => '',
             'badgeTitle' => '',
             'foo' => 'bar',
         ];


### PR DESCRIPTION
`BackendTemplate::compile` still sets `$this->ua = ''` (this cannot be removed as the `ua` template variable is generally used for the body CSS classes of the back end templates).